### PR TITLE
Initialize Node.js project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "fantasyspot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fantasyspot",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "fantasyspot",
+  "version": "1.0.0",
+  "description": "Fantasyspot project repository",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests implemented yet\" && exit 0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ZinoFlo/Fantasyspot.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/ZinoFlo/Fantasyspot/issues"
+  },
+  "homepage": "https://github.com/ZinoFlo/Fantasyspot#readme"
+}


### PR DESCRIPTION
Initialized the Node.js project by creating a `package.json` file. This allows `npm install` and `npm run test` to be executed successfully. The `test` script is set to echo a message and exit with code 0 to ensure it passes. metadata was also added to `package.json` including the repository URL and a description.

---
*PR created automatically by Jules for task [7210396044944146923](https://jules.google.com/task/7210396044944146923) started by @JulienVink*