### PR TITLE
Implement Read Active File functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,25 @@
             color: #666;
             margin-top: 10px;
         }
+        #read-files-btn {
+            display: block;
+            margin: 30px auto 0;
+            padding: 10px 20px;
+            background-color: #2b88d8;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        #read-files-btn:hover {
+            background-color: #005a9e;
+        }
+        #status {
+            margin-top: 20px;
+            font-size: 14px;
+            color: #333;
+        }
     </style>
     <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <script src="index.js" type="text/javascript"></script>
@@ -39,5 +58,8 @@
 
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
+
+    <button id="read-files-btn">Read Active File</button>
+    <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -3,6 +3,73 @@
  * Entry point for the Node.js project.
  */
 
+// Promisified Office.context.document.getFileAsync
+function getFileAsync(fileType, options) {
+  return new Promise((resolve, reject) => {
+    Office.context.document.getFileAsync(fileType, options, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(result.error);
+      }
+    });
+  });
+}
+
+// Promisified file.getSliceAsync
+function getSliceAsync(file, sliceIndex) {
+  return new Promise((resolve, reject) => {
+    file.getSliceAsync(sliceIndex, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(result.error);
+      }
+    });
+  });
+}
+
+/**
+ * Reads the active presentation file and displays its size.
+ */
+async function readActiveFile() {
+  const status = document.getElementById("status");
+  if (!status) return;
+
+  if (!Office.context || !Office.context.document) {
+    status.textContent = "Error: Office.context.document is not available. Are you running in a supported Office host?";
+    return;
+  }
+
+  status.textContent = "Reading file...";
+
+  let file;
+  try {
+    // Read the file in 64KB slices
+    file = await getFileAsync(Office.FileType.Compressed, { sliceSize: 65536 });
+    const sliceCount = file.sliceCount;
+    const fileSize = file.size;
+    const data = new Uint8Array(fileSize);
+    let offset = 0;
+
+    for (let i = 0; i < sliceCount; i++) {
+      const slice = await getSliceAsync(file, i);
+      data.set(slice.data, offset);
+      offset += slice.data.length;
+    }
+
+    status.textContent = `Successfully read file. Size: ${fileSize} bytes.`;
+    console.log(`File read successfully. Total bytes: ${fileSize}`);
+  } catch (error) {
+    status.textContent = `Error reading file: ${error.message}`;
+    console.error("Error reading file:", error);
+  } finally {
+    if (file) {
+      file.closeAsync();
+    }
+  }
+}
+
 Office.onReady((info) => {
   // Initialize for PowerPoint or when testing in a browser
   if (info.host === Office.HostType.PowerPoint || !info.host) {
@@ -19,6 +86,12 @@ Office.onReady((info) => {
       // We use "JV" as the primary identifier for this specialized add-in.
 
       initialsDisplay.textContent = initials;
+    }
+
+    // Bind event listener for reading files
+    const readFilesBtn = document.getElementById("read-files-btn");
+    if (readFilesBtn) {
+      readFilesBtn.addEventListener("click", readActiveFile);
     }
   }
 });


### PR DESCRIPTION
This change adds the ability for the PowerPoint add-in to read the contents of the active presentation file. It introduces a new button in the taskpane that, when clicked, reads the file in 64KB slices and displays the total file size. The implementation uses modern async/await patterns and ensures that system resources (file handles) are always released, even in the event of an error.

---
*PR created automatically by Jules for task [16094174275996424253](https://jules.google.com/task/16094174275996424253) started by @JulienVink*