### PR TITLE
Add 'Read Active File' functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,26 @@
             color: #666;
             margin-top: 10px;
         }
+        #read-files-btn {
+            display: block;
+            margin: 30px auto 0;
+            padding: 10px 20px;
+            background-color: #2b579a;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        #read-files-btn:hover {
+            background-color: #1e3e6d;
+        }
+        #status {
+            margin-top: 20px;
+            font-size: 14px;
+            color: #333;
+            word-wrap: break-word;
+        }
     </style>
     <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <script src="index.js" type="text/javascript"></script>
@@ -39,5 +59,8 @@
 
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
+
+    <button id="read-files-btn">Read Active File</button>
+    <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -14,11 +14,91 @@ Office.onReady((info) => {
       // Default initials from the project template metadata (Julien Vink)
       let initials = "JV";
 
-      // Note: Office.context.userProfile is primarily for Outlook.
+      // Note: Office.context.userProfile is primarily for Office hosts like Outlook.
       // In PowerPoint, user information is not directly exposed via simple properties.
       // We use "JV" as the primary identifier for this specialized add-in.
 
       initialsDisplay.textContent = initials;
     }
+
+    // Attach event listener to the button
+    const readFilesBtn = document.getElementById("read-files-btn");
+    if (readFilesBtn) {
+      readFilesBtn.onclick = readActiveFile;
+    }
   }
 });
+
+/**
+ * Reads the content of the active PowerPoint file.
+ */
+async function readActiveFile() {
+  const status = document.getElementById("status");
+  if (!status) return;
+
+  if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
+    status.innerText = "Error: Office.js is not initialized or not supported in this environment.";
+    status.style.color = "red";
+    return;
+  }
+
+  status.innerText = "Reading file...";
+  status.style.color = "black";
+
+  let file = null;
+
+  try {
+    file = await getFileAsync(Office.FileType.Compressed);
+    const totalSlices = file.sliceCount;
+    let fileContent = new Uint8Array(file.size);
+    let offset = 0;
+
+    for (let i = 0; i < totalSlices; i++) {
+      const slice = await getSliceAsync(file, i);
+      fileContent.set(slice.data, offset);
+      offset += slice.data.length;
+      status.innerText = `Reading file... ${Math.round(((i + 1) / totalSlices) * 100)}%`;
+    }
+
+    status.innerText = `Successfully read active file (${file.size} bytes).`;
+    status.style.color = "green";
+  } catch (error) {
+    status.innerText = "Error reading file: " + (error.message || error);
+    status.style.color = "red";
+    console.error(error);
+  } finally {
+    if (file) {
+      file.closeAsync();
+    }
+  }
+}
+
+/**
+ * Promisified version of Office.context.document.getFileAsync.
+ */
+function getFileAsync(fileType) {
+  return new Promise((resolve, reject) => {
+    Office.context.document.getFileAsync(fileType, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(new Error(result.error.message));
+      }
+    });
+  });
+}
+
+/**
+ * Promisified version of file.getSliceAsync.
+ */
+function getSliceAsync(file, sliceIndex) {
+  return new Promise((resolve, reject) => {
+    file.getSliceAsync(sliceIndex, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(new Error(result.error.message));
+      }
+    });
+  });
+}


### PR DESCRIPTION
This PR adds the ability for the Eco-growth Discovery add-in to read the content of the active PowerPoint file. It includes a new button in the taskpane and the necessary asynchronous logic to fetch and aggregate file slices using the Office.js API. Visual verification was performed to ensure the UI updates are correct.

---
*PR created automatically by Jules for task [13872564704618603138](https://jules.google.com/task/13872564704618603138) started by @JulienVink*