### PR TITLE
Add ability to read active file content

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,26 @@
             color: #666;
             margin-top: 10px;
         }
+        #read-files-btn {
+            display: block;
+            margin: 30px auto 0;
+            padding: 10px 20px;
+            background-color: #0078d4;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        #read-files-btn:hover {
+            background-color: #005a9e;
+        }
+        #status {
+            margin-top: 20px;
+            font-size: 14px;
+            color: #333;
+            word-wrap: break-word;
+        }
     </style>
     <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <script src="index.js" type="text/javascript"></script>
@@ -39,5 +59,8 @@
 
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
+
+    <button id="read-files-btn">Read Active File</button>
+    <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -3,6 +3,51 @@
  * Entry point for the Node.js project.
  */
 
+/**
+ * Promisified wrapper for Office.context.document.getFileAsync
+ */
+function getFileAsync(fileType, options) {
+  return new Promise((resolve, reject) => {
+    Office.context.document.getFileAsync(fileType, options, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(result.error);
+      }
+    });
+  });
+}
+
+/**
+ * Promisified wrapper for file.getSliceAsync
+ */
+function getSliceAsync(file, sliceIndex) {
+  return new Promise((resolve, reject) => {
+    file.getSliceAsync(sliceIndex, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(result.error);
+      }
+    });
+  });
+}
+
+/**
+ * Promisified wrapper for file.closeAsync
+ */
+function closeAsync(file) {
+  return new Promise((resolve, reject) => {
+    file.closeAsync((result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve();
+      } else {
+        reject(result.error);
+      }
+    });
+  });
+}
+
 Office.onReady((info) => {
   // Initialize for PowerPoint or when testing in a browser
   if (info.host === Office.HostType.PowerPoint || !info.host) {
@@ -20,5 +65,56 @@ Office.onReady((info) => {
 
       initialsDisplay.textContent = initials;
     }
+
+    // Bind event listener for reading files
+    const readFilesBtn = document.getElementById("read-files-btn");
+    if (readFilesBtn) {
+      readFilesBtn.onclick = readActiveFile;
+    }
   }
 });
+
+/**
+ * Reads the active PowerPoint file as a byte stream.
+ */
+async function readActiveFile() {
+  const status = document.getElementById("status");
+  if (!status) return;
+
+  if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
+    status.innerText = "Office context not available. This function requires running within PowerPoint.";
+    return;
+  }
+
+  status.innerText = "Reading file...";
+
+  let file = null;
+  try {
+    // Office.FileType.Compressed returns the entire presentation as a .pptx file byte stream.
+    file = await getFileAsync(Office.FileType.Compressed, { sliceSize: 65536 });
+    const sliceCount = file.sliceCount;
+    const fileData = new Uint8Array(file.size);
+    let offset = 0;
+
+    for (let i = 0; i < sliceCount; i++) {
+      const slice = await getSliceAsync(file, i);
+      fileData.set(slice.data, offset);
+      offset += slice.data.length;
+      status.innerText = `Reading slice ${i + 1} of ${sliceCount}...`;
+    }
+
+    status.innerText = `Successfully read active file: ${file.size} bytes.`;
+    console.log("File content aggregated.", fileData);
+  } catch (error) {
+    console.error("Error reading file:", error);
+    status.innerText = `Error reading file: ${error.message || error}`;
+  } finally {
+    if (file) {
+      try {
+        await closeAsync(file);
+      } catch (closeError) {
+        console.error("Error closing file:", closeError);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change adds the ability for the PowerPoint add-in to read the content of the active presentation. 

Key changes:
1.  **UI Updates**: A new button "Read Active File" and a status display area were added to the taskpane (`index.html`).
2.  **API Wrappers**: Callback-based Office.js APIs (`getFileAsync`, `getSliceAsync`, `closeAsync`) were promisified in `index.js` to allow for cleaner `async/await` logic.
3.  **File Reading Logic**: The `readActiveFile` function retrieves the entire presentation as a compressed byte stream, iterates through all file slices, and aggregates them into a `Uint8Array`.
4.  **Robustness**: Included environment checks to provide helpful messages when running outside of PowerPoint and ensured that files are always closed to prevent locking.
5.  **Verification**: The UI was verified using a Playwright script, and code review feedback was addressed.

---
*PR created automatically by Jules for task [2299422144758743039](https://jules.google.com/task/2299422144758743039) started by @JulienVink*