### PR TITLE
Implement read active file functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,21 @@
             color: #666;
             margin-top: 10px;
         }
+        #read-files-btn {
+            display: block;
+            margin: 30px auto 0;
+            padding: 10px 20px;
+            background-color: #0078d4;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        #status {
+            margin-top: 20px;
+            font-size: 14px;
+            color: #333;
+        }
     </style>
     <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <script src="index.js" type="text/javascript"></script>
@@ -39,5 +54,8 @@
 
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
+
+    <button id="read-files-btn">Read Active File</button>
+    <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -20,5 +20,82 @@ Office.onReady((info) => {
 
       initialsDisplay.textContent = initials;
     }
+
+    // Attach event listener to the button
+    const readFilesBtn = document.getElementById("read-files-btn");
+    if (readFilesBtn) {
+      readFilesBtn.onclick = readActiveFile;
+    }
+  } else {
+    const status = document.getElementById("status");
+    if (status) {
+      status.textContent = "This add-in is only supported in PowerPoint.";
+    }
   }
 });
+
+/**
+ * Reads the active PowerPoint file.
+ */
+async function readActiveFile() {
+  const status = document.getElementById("status");
+  if (!status) return;
+
+  if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
+    status.textContent = "Office context is not available.";
+    return;
+  }
+
+  status.textContent = "Reading file...";
+
+  try {
+    const file = await getFileAsync(Office.FileType.Compressed);
+    const fileData = new Uint8Array(file.size);
+    let offset = 0;
+
+    try {
+      for (let i = 0; i < file.sliceCount; i++) {
+        const slice = await getSliceAsync(file, i);
+        fileData.set(slice.value, offset);
+        offset += slice.value.length;
+      }
+      status.textContent = `Successfully read file. Size: ${file.size} bytes.`;
+      console.log("File read successfully.", fileData);
+    } finally {
+      file.closeAsync();
+    }
+  } catch (error) {
+    status.textContent = `Error reading file: ${error.message}`;
+    console.error(error);
+  }
+}
+
+/**
+ * Promisified version of Office.context.document.getFileAsync
+ */
+function getFileAsync(fileType) {
+  return new Promise((resolve, reject) => {
+    Office.context.document.getFileAsync(fileType, { sliceSize: 65536 }, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(new Error(result.error.message));
+      }
+    });
+  });
+}
+
+/**
+ * Promisified version of file.getSliceAsync
+ */
+function getSliceAsync(file, sliceIndex) {
+  return new Promise((resolve, reject) => {
+    file.getSliceAsync(sliceIndex, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(new Error(result.error.message));
+      }
+    });
+  });
+}


### PR DESCRIPTION
I have implemented the functionality to read the active PowerPoint file.

Key changes:
- Added a "Read Active File" button and a status display area in `index.html`.
- Implemented `readActiveFile` in `index.js`, which uses the chunked reading approach required by Office.js to retrieve the full byte stream of the active presentation.
- Added promisified wrappers `getFileAsync` and `getSliceAsync` to simplify asynchronous file reading.
- Included defensive checks to ensure the add-in provides helpful feedback when running outside of a supported PowerPoint host.
- Verified the UI changes using a Playwright script and confirmed the layout and basic error handling.

---
*PR created automatically by Jules for task [3844140194529446608](https://jules.google.com/task/3844140194529446608) started by @JulienVink*