### PR TITLE
Implement 'Read Active File' functionality in PowerPoint Add-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,31 @@
             color: #666;
             margin-top: 10px;
         }
+        #read-files-btn {
+            display: block;
+            margin: 30px auto 0;
+            padding: 10px 20px;
+            background-color: #217346;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        #read-files-btn:hover {
+            background-color: #1a5a37;
+        }
+        #status {
+            margin-top: 20px;
+            font-size: 14px;
+            color: #333;
+            text-align: left;
+            padding: 10px;
+            background-color: #f3f2f1;
+            border-radius: 4px;
+            min-height: 1.2em;
+            word-break: break-all;
+        }
     </style>
     <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <script src="index.js" type="text/javascript"></script>
@@ -39,5 +64,8 @@
 
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
+
+    <button id="read-files-btn">Read Active File</button>
+    <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -20,5 +20,106 @@ Office.onReady((info) => {
 
       initialsDisplay.textContent = initials;
     }
+
+    // Attach event listener to the "Read Active File" button
+    const readBtn = document.getElementById("read-files-btn");
+    if (readBtn) {
+      readBtn.onclick = readActiveFile;
+    }
   }
 });
+
+/**
+ * Promisified wrapper for Office.context.document.getFileAsync.
+ */
+function getFileAsync(fileType, options) {
+  return new Promise((resolve, reject) => {
+    Office.context.document.getFileAsync(fileType, options, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(result.error);
+      }
+    });
+  });
+}
+
+/**
+ * Promisified wrapper for file.getSliceAsync.
+ */
+function getSliceAsync(file, sliceIndex) {
+  return new Promise((resolve, reject) => {
+    file.getSliceAsync(sliceIndex, (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(result.value);
+      } else {
+        reject(result.error);
+      }
+    });
+  });
+}
+
+/**
+ * Promisified wrapper for file.closeAsync.
+ */
+function closeAsync(file) {
+  return new Promise((resolve) => {
+    file.closeAsync(() => {
+      resolve();
+    });
+  });
+}
+
+/**
+ * Reads the active PowerPoint file as a compressed byte stream.
+ */
+async function readActiveFile() {
+  const status = document.getElementById("status");
+  if (status) status.textContent = "Reading file...";
+
+  if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
+    const errorMsg = "Office.js is not loaded or this is not an Office host.";
+    console.error(errorMsg);
+    if (status) status.textContent = errorMsg;
+    return;
+  }
+
+  let file = null;
+  try {
+    // 1. Get the file handle
+    file = await getFileAsync(Office.FileType.Compressed, { sliceSize: 65536 });
+    const sliceCount = file.sliceCount;
+    const fileSize = file.size;
+
+    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+
+    // 2. Pre-allocate Uint8Array for the file content
+    const fileData = new Uint8Array(fileSize);
+    let offset = 0;
+
+    // 3. Read slices sequentially
+    for (let i = 0; i < sliceCount; i++) {
+      const slice = await getSliceAsync(file, i);
+      fileData.set(slice.data, offset);
+      offset += slice.data.length;
+
+      if (status) {
+        status.textContent = `Reading progress: ${Math.round(((i + 1) / sliceCount) * 100)}%`;
+      }
+    }
+
+    if (status) {
+      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+    }
+    console.log(`Read ${fileSize} bytes from the active presentation.`);
+  } catch (error) {
+    const errorMsg = `Error reading file: ${error.message || error}`;
+    console.error(errorMsg);
+    if (status) status.textContent = errorMsg;
+  } finally {
+    // 4. Always close the file handle
+    if (file) {
+      await closeAsync(file);
+    }
+  }
+}


### PR DESCRIPTION
This change implements the ability for the PowerPoint add-in to read the contents of the currently active presentation. It adds a user-facing button to the taskpane that, when clicked, triggers a process to read the file in slices as a compressed byte stream. The progress and result (file size) are displayed in the UI. The implementation uses asynchronous, promisified wrappers for the Office.js callback-based APIs and ensures that file handles are always closed in a finally block to prevent resource leaks.

---
*PR created automatically by Jules for task [14562669829643366055](https://jules.google.com/task/14562669829643366055) started by @JulienVink*