### PR TITLE
Implement 'Read Active Files' UI and code terminology update

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,7 @@
             color: #666;
             margin-top: 10px;
         }
-        #read-files-btn {
-            display: block;
-            margin: 30px auto 0;
+        .read-btn {
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -39,10 +37,10 @@
             cursor: pointer;
             font-size: 16px;
         }
-        #read-files-btn:hover {
+        .read-btn:hover {
             background-color: #1a5a37;
         }
-        #status {
+        .status-box {
             margin-top: 20px;
             font-size: 14px;
             color: #333;
@@ -65,7 +63,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
-    <div id="status"></div>
+    <div style="margin-top: 30px;">
+        <button id="read-files-btn" class="read-btn">Read Active Files</button>
+    </div>
+    <div id="status" class="status-box"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,11 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint files as a compressed byte stream.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading files...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +109,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active files: ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentations.`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
I have updated the PowerPoint Add-in's taskpane UI and underlying JavaScript to consistently use the terminology "Read Active Files" as requested. 

Key changes include:
1. **HTML/CSS Refactoring**: 
   - Renamed the button label to "Read Active Files".
   - Moved CSS styles from the `#read-files-btn` ID and `#status` ID into reusable `.read-btn` and `.status-box` classes.
   - Wrapped the button in a `div` with a 30px top margin to ensure proper spacing and alignment.
2. **JavaScript Updates**:
   - Renamed the primary file-reading function to `readActiveFiles`.
   - Updated the click event listener and all user-facing status messages to reflect the pluralized "files" terminology.
   - Verified the UI changes visually using a Playwright script and confirmed that the local development server correctly serves the updated assets.
3. **Cleaned Up Environment**:
   - Ensured that temporary files like `server.log` and unzipped PowerPoint artifacts are not included in the commit.

---
*PR created automatically by Jules for task [6216468224670731484](https://jules.google.com/task/6216468224670731484) started by @JulienVink*