### PR TITLE
Pluralize 'Read Active File' terminology and update UI layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log

--- a/index.html
+++ b/index.html
@@ -65,7 +65,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div style="margin-top: 30px;">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,11 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +109,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes. Total slices: ${sliceCount}.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
This change updates the PowerPoint add-in to use plural terminology ("Read Active Files") in both the UI and the underlying JavaScript code. It also improves the user feedback by including the total number of slices processed during the file read operation. Additionally, it ensures better project maintenance by excluding the `server.log` file from the repository.

---
*PR created automatically by Jules for task [17536561481056751986](https://jules.google.com/task/17536561481056751986) started by @JulienVink*