### PR TITLE
Refactor to 'Read Active Files' plural terminology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,11 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint presentation(s) as a compressed byte stream.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active presentation(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,11 +109,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active presentation: ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading presentation(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {


### PR DESCRIPTION
This change renames the existing single-file reading logic and UI labels to plural form to align with project standards and user expectations for 'Read Active Files'. It also includes minor layout improvements and ensures development artifacts are ignored by git.

---
*PR created automatically by Jules for task [10370772827206708492](https://jules.google.com/task/10370772827206708492) started by @JulienVink*