### PR TITLE
Standardize 'Read Active Files' UI and logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ Office.onReady((info) => {
     // Attach event listener to the "Read Active File" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -73,9 +73,9 @@ function closeAsync(file) {
 /**
  * Reads the active PowerPoint file as a compressed byte stream.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +109,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
This change standardizes the 'Read Active Files' functionality to use plural phrasing throughout the UI and code, as per project requirements. It includes renaming the core reading function, updating user-facing status messages, and adjusting the taskpane layout for consistency. Additionally, `server.log` is added to `.gitignore` to prevent local logs from being committed.

---
*PR created automatically by Jules for task [209853217936854481](https://jules.google.com/task/209853217936854481) started by @JulienVink*