### PR TITLE
Update UI and logic to use plural terminology for reading active files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,12 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint presentation(s).
+ * Note: pluralized terminology is used for design consistency, although Office JS API currently reads the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +110,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
This PR updates the PowerPoint add-in to use plural terminology ("Read Active Files") for consistency in the UI and code, even though the Office JS API currently limits reading to the single active presentation. It also improves the UI structure by wrapping the action button in a dedicated container and ensures development artifacts like log files are excluded from the repository.

---
*PR created automatically by Jules for task [9382547228462392569](https://jules.google.com/task/9382547228462392569) started by @JulienVink*