### PR TITLE
Pluralize 'Read Active File' terminology in UI and code

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -72,10 +72,12 @@ function closeAsync(file) {
 
 /**
  * Reads the active PowerPoint file as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency,
+ * though technically only the active presentation is read.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +111,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
I have updated the application to use pluralized terminology for "reading active files," as requested. 

Key changes include:
1.  **Code Consistency:** Renamed the primary file-reading function in `index.js` to `readActiveFiles` and updated all internal references and status/console logs to use plural phrasing (e.g., "active file(s)").
2.  **UI Alignment:** Updated the button label in `index.html` to "Read Active Files" to match the requested terminology.
3.  **Layout Improvement:** Wrapped the "Read Active Files" button in a `.button-container` and adjusted CSS margins to delegate top-spacing to the container, maintaining visual alignment while following better design patterns.
4.  **Clarification:** Added a documentation comment to the `readActiveFiles` function explaining that pluralized terminology is used for design consistency, even though the Office JS API is technically limited to reading the single active presentation.

Verified the changes via a Playwright script to ensure the UI is correctly rendered and the button text is updated.

---
*PR created automatically by Jules for task [9838328250779312553](https://jules.google.com/task/9838328250779312553) started by @JulienVink*