### PR TITLE
Pluralize terminology for reading active files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log
+test-results/

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency,
+ * although technically it reads the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +111,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
This change updates the PowerPoint add-in to use pluralized terminology ("Read Active Files") for its primary file-reading functionality, aligning with the requested user experience. While the underlying Office.js API currently supports reading the single active presentation, the UI and internal function names now use plural phrasing for design consistency. 

Key changes:
- Refactored `index.js`: renamed `readActiveFile` to `readActiveFiles`, updated all references, and standardized status/log messages (e.g., "Reading active file(s)...").
- Updated `index.html`: changed button label and introduced a `.button-container` with appropriate CSS margins for better layout.
- Enhanced `.gitignore`: added entries for `server.log` and `test-results/` to prevent local development artifacts from being committed.
- Verified changes with a Playwright test and manual inspection of generated screenshots.

---
*PR created automatically by Jules for task [2254741636173075491](https://jules.google.com/task/2254741636173075491) started by @JulienVink*