### PR TITLE
Pluralize 'Read Active Files' terminology

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -41,6 +41,9 @@
         }
         #read-files-btn:hover {
             background-color: #1a5a37;
+        }
+        .button-container {
+            margin-top: 30px;
         }
         #status {
             margin-top: 20px;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency, though
+ * getFileAsync specifically accesses the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +111,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
Updated the PowerPoint Add-in to use pluralized terminology for reading active files. This included renaming the main function, updating UI labels, and improving the button's layout using a container. Plural terminology was adopted for design consistency across the application.

---
*PR created automatically by Jules for task [8194623707817001524](https://jules.google.com/task/8194623707817001524) started by @JulienVink*