### PR TITLE
Pluralize 'Read Active File' UI and Logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -72,10 +72,12 @@ function closeAsync(file) {
 
 /**
  * Reads the active PowerPoint file as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency, despite the
+ * technical limitation of getFileAsync to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -91,7 +93,7 @@ async function readActiveFile() {
     const sliceCount = file.sliceCount;
     const fileSize = file.size;
 
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices from the active presentation(s)...`;
 
     // 2. Pre-allocate Uint8Array for the file content
     const fileData = new Uint8Array(fileSize);
@@ -109,11 +111,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {


### PR DESCRIPTION
This change updates the PowerPoint Add-in's UI and JavaScript logic to use plural terminology ("Read Active Files") for consistency with project design standards. 

Key changes include:
- Renaming the core file-reading function to `readActiveFiles`.
- Updating the UI button label and its styling/structure in `index.html`.
- Standardizing status updates and console logs to reflect the pluralized naming.
- Adding a comment in `index.js` to clarify that while the UI is pluralized, the underlying Office JS API (`getFileAsync`) remains technically limited to the single active presentation.

Verified the changes via a local development server and Playwright test suite (not included in commit). All temporary artifacts and test dependencies have been removed.

---
*PR created automatically by Jules for task [15756803706540458342](https://jules.google.com/task/15756803706540458342) started by @JulienVink*