### PR TITLE
Pluralize "Read Active File" feature and update layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -72,10 +72,14 @@ function closeAsync(file) {
 
 /**
  * Reads the active PowerPoint file as a compressed byte stream.
+ *
+ * Note: Plural terminology (e.g., "active files") is used for design consistency
+ * and future-proofing, although current technical limitations (getFileAsync)
+ * restrict reading to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +113,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
This PR updates the "Read Active File" feature to use plural terminology ("Read Active Files") across the UI and codebase, aligning it with design consistency requirements.

Key changes:
- **index.html**: Changed button text to "Read Active Files", wrapped it in a `button-container` div, and updated CSS for a consistent layout (30px top margin).
- **index.js**: Renamed the core function to `readActiveFiles`, updated the event listener, and changed status messages/console logs to use plural phrasing (e.g., "active file(s)", "presentation(s)").
- **Documentation**: Added a comment to `readActiveFiles` explaining that while the UI is pluralized for design consistency and future-proofing, current technical limitations (Office JS `getFileAsync`) restrict reading to the single active presentation.

Verified with Playwright tests ensuring the new layout and pluralized status messages are correctly rendered and functional.

---
*PR created automatically by Jules for task [2279718037290592075](https://jules.google.com/task/2279718037290592075) started by @JulienVink*