### PR TITLE
Pluralize Read Active Files functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency despite the
+ * technical limitation of getFileAsync to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -91,7 +93,7 @@ async function readActiveFile() {
     const sliceCount = file.sliceCount;
     const fileSize = file.size;
 
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slice(s)...`;
 
     // 2. Pre-allocate Uint8Array for the file content
     const fileData = new Uint8Array(fileSize);
@@ -109,11 +111,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {


### PR DESCRIPTION
This change updates the "Read Active File" functionality to "Read Active Files" across the application's UI and codebase. While the underlying Office JS API (`getFileAsync`) is technically limited to the single active presentation, the terminology has been pluralized to align with design requirements and provide a consistent user experience. The button has also been wrapped in a container for better layout management. All changes have been verified with a Playwright script and manual visual inspection.

---
*PR created automatically by Jules for task [8621130718906122337](https://jules.google.com/task/8621130718906122337) started by @JulienVink*