### PR TITLE
Pluralize Read Active File terminology

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -72,10 +72,12 @@ function closeAsync(file) {
 
 /**
  * Reads the active PowerPoint file as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency,
+ * though technically only the active presentation is read.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,11 +111,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading active file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {


### PR DESCRIPTION
Updated the taskpane UI and JavaScript logic to use pluralized terminology ("Read Active Files") for design consistency. Renamed the core reading function, updated status messages, and improved the button layout with a new container. Verified the changes with a mocked Office.js environment using Playwright.

---
*PR created automatically by Jules for task [2120879967171150026](https://jules.google.com/task/2120879967171150026) started by @JulienVink*