### PR TITLE
Pluralize Read Active Files UI and Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log
+
+# Test results
+test-results/

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: While the UI uses plural for consistency, the Office JS API
+ * currently focuses on the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +111,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
This PR updates the PowerPoint Add-in to use plural terminology for reading active files, aligning with the user's request. 

Key changes:
1.  **Pluralization**: Updated the UI button label, status messages, and internal function names from "Read Active File" to "Read Active Files". While the underlying Office JS API (`getFileAsync`) is currently limited to the single active presentation, the UI now reflects a more consistent design for potential future multi-file support.
2.  **Layout Improvement**: Wrapped the "Read Active Files" button in a `button-container` with a 30px top margin and centered the button using `margin: 0 auto`.
3.  **Maintenance**: Updated `.gitignore` to exclude `server.log` and `test-results/` to keep the repository clean.
4.  **Verification**: Verified UI changes and CSS layout using Playwright. Temporary testing dependencies were removed and are not included in `package.json`.

---
*PR created automatically by Jules for task [11643845771851816847](https://jules.google.com/task/11643845771851816847) started by @JulienVink*