### PR TITLE
Pluralize 'Read Active File' UI and internal terminology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ appengine-generated/
 
 # Node.js
 node_modules/
+/test-results/
 npm-debug.log

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency,
+ * although getFileAsync currently reads the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,9 +111,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);


### PR DESCRIPTION
This change updates the PowerPoint Add-in UI and internal code to use plural terminology ("Read Active Files") for a more consistent user experience, even though the underlying Office JS API is currently limited to the single active presentation.

Key changes:
- UI: Button label changed to "Read Active Files" and centered within a new `.button-container`.
- Logic: `readActiveFile` renamed to `readActiveFiles` and all user-facing status messages updated to "active file(s)".
- Maintenance: `.gitignore` updated to exclude `/test-results/` generated by Playwright.

Verified with Playwright (Node.js and Python) to ensure correct UI rendering, layout (30px margin), and initials transition.

---
*PR created automatically by Jules for task [11743477179739630100](https://jules.google.com/task/11743477179739630100) started by @JulienVink*