### PR TITLE
Pluralize Read Active Files Terminology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,8 @@ jobs:
     - run: npm install
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps chromium
+    - name: Start Server
+      run: npm start > server.log 2>&1 &
+    - name: Wait for Server
+      run: sleep 5
     - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         node-version: '20'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+/test-results/

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: Plural terminology is used for design consistency, though getFileAsync
+ * is currently limited to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -91,7 +93,7 @@ async function readActiveFile() {
     const sliceCount = file.sliceCount;
     const fileSize = file.size;
 
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slice(s)...`;
 
     // 2. Pre-allocate Uint8Array for the file content
     const fileData = new Uint8Array(fileSize);
@@ -109,9 +111,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,25 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "http-server": "^14.1.1"
+        "@playwright/test": "^1.60.0",
+        "http-server": "^14.1.1",
+        "playwright": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +236,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +491,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,8 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
-    "http-server": "^14.1.1"
+    "@playwright/test": "^1.60.0",
+    "http-server": "^14.1.1",
+    "playwright": "^1.60.0"
   }
 }

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,66 @@
+const { test, expect } = require('@playwright/test');
+
+test('Verify pluralization and UI updates', async ({ page }) => {
+  // Mock Office.js and the Office object
+  await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async (route) => {
+    await route.fulfill({ body: '// Mock Office.js' });
+  });
+
+  await page.addInitScript(() => {
+    window.Office = {
+      onReady: (callback) => {
+        setTimeout(() => callback({ host: 'PowerPoint' }), 100);
+      },
+      HostType: { PowerPoint: 'PowerPoint' },
+      FileType: { Compressed: 'Compressed' },
+      AsyncResultStatus: { Succeeded: 'Succeeded', Failed: 'Failed' },
+      context: {
+        document: {
+          getFileAsync: (fileType, options, callback) => {
+            setTimeout(() => {
+              callback({
+                status: 'Succeeded',
+                value: {
+                  size: 100,
+                  sliceCount: 1,
+                  getSliceAsync: (index, sliceCallback) => {
+                    setTimeout(() => {
+                      sliceCallback({
+                        status: 'Succeeded',
+                        value: { data: new Uint8Array(100) }
+                      });
+                    }, 50);
+                  },
+                  closeAsync: (closeCallback) => {
+                    setTimeout(() => closeCallback(), 10);
+                  }
+                }
+              });
+            }, 50);
+          }
+        }
+      }
+    };
+  });
+
+  await page.goto('http://localhost:3000/index.html');
+
+  // Verify initials updated (confirming Office.onReady fired)
+  const initials = page.locator('#initials-display');
+  await expect(initials).toHaveText('JV');
+
+  // Verify button text is pluralized
+  const button = page.locator('#read-files-btn');
+  await expect(button).toHaveText('Read Active Files');
+
+  // Verify CSS centering and container margin
+  const container = page.locator('.button-container');
+  const marginTop = await container.evaluate((el) => window.getComputedStyle(el).marginTop);
+  expect(marginTop).toBe('30px');
+
+  // Click button and verify status messages
+  await button.click();
+
+  const status = page.locator('#status');
+  await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes\./, { timeout: 5000 });
+});


### PR DESCRIPTION
I have updated the PowerPoint Add-in to use pluralized terminology for reading active files, aligning with the project's design guidelines. This involved renaming the core reading function to `readActiveFiles`, updating UI labels and status messages, and improving the layout with a new button container and CSS centering. Additionally, I moved Playwright to `devDependencies` and configured the `npm test` script to support automated UI verification.

---
*PR created automatically by Jules for task [14942761869097739097](https://jules.google.com/task/14942761869097739097) started by @JulienVink*