### PR TITLE
Pluralize "Read Active Files" and add UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         node-version: '20'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
     - run: npm test

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,13 +21,69 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
+
+/**
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: While the UI uses plural terminology for design consistency,
+ * Office.context.document.getFileAsync reads the single active presentation.
+ */
+async function readActiveFiles() {
+  const status = document.getElementById("status");
+  if (status) status.textContent = "Reading active file(s)...";
+
+  if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
+    const errorMsg = "Office.js is not loaded or this is not an Office host.";
+    console.error(errorMsg);
+    if (status) status.textContent = errorMsg;
+    return;
+  }
+
+  let file = null;
+  try {
+    // 1. Get the file handle
+    file = await getFileAsync(Office.FileType.Compressed, { sliceSize: 65536 });
+    const sliceCount = file.sliceCount;
+    const fileSize = file.size;
+
+    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+
+    // 2. Pre-allocate Uint8Array for the file content
+    const fileData = new Uint8Array(fileSize);
+    let offset = 0;
+
+    // 3. Read slices sequentially
+    for (let i = 0; i < sliceCount; i++) {
+      const slice = await getSliceAsync(file, i);
+      fileData.set(slice.data, offset);
+      offset += slice.data.length;
+
+      if (status) {
+        status.textContent = `Reading progress: ${Math.round(((i + 1) / sliceCount) * 100)}%`;
+      }
+    }
+
+    if (status) {
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
+    }
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
+  } catch (error) {
+    const errorMsg = `Error reading file(s): ${error.message || error}`;
+    console.error(errorMsg);
+    if (status) status.textContent = errorMsg;
+  } finally {
+    // 4. Always close the file handle
+    if (file) {
+      await closeAsync(file);
+    }
+  }
+}
 
 /**
  * Promisified wrapper for Office.context.document.getFileAsync.
@@ -68,58 +124,4 @@ function closeAsync(file) {
       resolve();
     });
   });
-}
-
-/**
- * Reads the active PowerPoint file as a compressed byte stream.
- */
-async function readActiveFile() {
-  const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
-
-  if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
-    const errorMsg = "Office.js is not loaded or this is not an Office host.";
-    console.error(errorMsg);
-    if (status) status.textContent = errorMsg;
-    return;
-  }
-
-  let file = null;
-  try {
-    // 1. Get the file handle
-    file = await getFileAsync(Office.FileType.Compressed, { sliceSize: 65536 });
-    const sliceCount = file.sliceCount;
-    const fileSize = file.size;
-
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
-
-    // 2. Pre-allocate Uint8Array for the file content
-    const fileData = new Uint8Array(fileSize);
-    let offset = 0;
-
-    // 3. Read slices sequentially
-    for (let i = 0; i < sliceCount; i++) {
-      const slice = await getSliceAsync(file, i);
-      fileData.set(slice.data, offset);
-      offset += slice.data.length;
-
-      if (status) {
-        status.textContent = `Reading progress: ${Math.round(((i + 1) / sliceCount) * 100)}%`;
-      }
-    }
-
-    if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
-    }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
-  } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
-    console.error(errorMsg);
-    if (status) status.textContent = errorMsg;
-  } finally {
-    // 4. Always close the file handle
-    if (file) {
-      await closeAsync(file);
-    }
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.40.0",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.40.0",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  webServer: {
+    command: 'npm start',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+  },
+  testDir: 'tests',
+};

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -63,6 +63,9 @@ test.describe('Eco-growth Discovery UI', () => {
     const readBtn = page.locator('#read-files-btn');
     const status = page.locator('#status');
 
+    // Wait for initials to ensure Office environment is initialized
+    await expect(page.locator('#initials-display')).toHaveText('JV');
+
     await readBtn.click();
     await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes/);
   });

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,92 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Eco-growth Discovery UI', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept Office.js script and return a mock
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: '// Mock Office.js',
+      });
+    });
+
+    // Inject mock Office object before scripts run
+    await page.addInitScript(() => {
+      window.Office = {
+        onReady: (cb) => {
+          // Trigger onReady with a slight delay
+          setTimeout(() => {
+            cb({ host: null });
+          }, 100);
+        },
+        HostType: { PowerPoint: 'PowerPoint' },
+        AsyncResultStatus: { Succeeded: 'Succeeded', Failed: 'Failed' },
+        FileType: { Compressed: 'Compressed' },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              callback({
+                status: 'Succeeded',
+                value: {
+                  size: 100,
+                  sliceCount: 1,
+                  getSliceAsync: (index, cb) => {
+                    cb({
+                      status: 'Succeeded',
+                      value: { data: new Uint8Array(100) },
+                    });
+                  },
+                  closeAsync: (cb) => cb(),
+                },
+              });
+            },
+          },
+        },
+      };
+    });
+
+    await page.goto('/index.html');
+  });
+
+  test('should display correct title and button text', async ({ page }) => {
+    await expect(page.locator('h1')).toHaveText('Eco-growth Discovery');
+    await expect(page.locator('#read-files-btn')).toHaveText('Read Active Files');
+  });
+
+  test('should initialize initials and display "JV"', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    await expect(initials).toHaveText('JV');
+  });
+
+  test('should show success message when button is clicked', async ({ page }) => {
+    const readBtn = page.locator('#read-files-btn');
+    const status = page.locator('#status');
+
+    await readBtn.click();
+    await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes/);
+  });
+
+  test('button container should have correct margin-top', async ({ page }) => {
+    const container = page.locator('.button-container');
+    const marginTop = await container.evaluate((el) => window.getComputedStyle(el).marginTop);
+    expect(marginTop).toBe('30px');
+  });
+
+  test('button should be centered', async ({ page }) => {
+    const button = page.locator('#read-files-btn');
+    const styles = await button.evaluate((el) => {
+      const s = window.getComputedStyle(el);
+      return {
+        marginLeft: parseFloat(s.marginLeft),
+        marginRight: parseFloat(s.marginRight),
+        display: s.display
+      };
+    });
+
+    expect(styles.display).toBe('block');
+    // For auto margin, we expect both to be equal and non-zero (if viewport > button width)
+    expect(styles.marginLeft).toBeGreaterThan(0);
+    expect(Math.abs(styles.marginLeft - styles.marginRight)).toBeLessThan(1);
+  });
+});


### PR DESCRIPTION
This PR aligns the "Read Active Files" functionality with project standards by pluralizing UI labels and function names for design consistency. It also introduces a Playwright-based testing suite to ensure UI correctness and layout integrity.

Key changes:
- Button renamed to "Read Active Files" in index.html.
- Button layout improved with a .button-container (30px top margin).
- Function renamed to readActiveFiles in index.js.
- Status messages and console logs updated to use plural phrasing ('active file(s)', 'presentation(s)').
- Automated UI tests added in tests/ui.spec.js.

---
*PR created automatically by Jules for task [16244699497709699760](https://jules.google.com/task/16244699497709699760) started by @JulienVink*