### PR TITLE
Read Active Files - Pluralization and E2E Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm install
-    - run: npm test
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
+    - name: Run tests
+      run: npm test

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -72,10 +72,12 @@ function closeAsync(file) {
 
 /**
  * Reads the active PowerPoint file as a compressed byte stream.
+ * Pluralized terminology (active files) is used for design consistency,
+ * despite getFileAsync being technically limited to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,11 +111,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.49.1",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  webServer: {
+    command: 'npm start',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+};

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,86 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Eco-growth Discovery Add-in UI', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept Office.js script request and mock it
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: 'window.Office = window.Office || {};'
+      });
+    });
+
+    // Inject Office mock BEFORE the application scripts load
+    await page.addInitScript(() => {
+      window.Office = {
+        onReady: (callback) => {
+          setTimeout(() => {
+            callback({ host: null }); // Simulate browser environment
+          }, 100);
+        },
+        HostType: {
+          PowerPoint: 'PowerPoint'
+        },
+        FileType: {
+          Compressed: 'compressed'
+        },
+        AsyncResultStatus: {
+          Succeeded: 'succeeded',
+          Failed: 'failed'
+        },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              console.log('getFileAsync called');
+              setTimeout(() => {
+                callback({
+                  status: 'succeeded',
+                  value: {
+                    size: 100,
+                    sliceCount: 1,
+                    getSliceAsync: (index, sliceCallback) => {
+                      setTimeout(() => {
+                        sliceCallback({
+                          status: 'succeeded',
+                          value: { data: new Uint8Array(100) }
+                        });
+                      }, 50);
+                    },
+                    closeAsync: (closeCallback) => {
+                      if (closeCallback) closeCallback();
+                    }
+                  }
+                });
+              }, 50);
+            }
+          }
+        }
+      };
+    });
+
+    await page.goto('http://localhost:3000/index.html');
+  });
+
+  test('should display correctly initialized initials', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    await expect(initials).toHaveText('JV', { timeout: 10000 });
+  });
+
+  test('should have pluralized button text', async ({ page }) => {
+    const button = page.locator('#read-files-btn');
+    await expect(button).toHaveText('Read Active Files');
+  });
+
+  test('should show success message when reading active files', async ({ page }) => {
+    const button = page.locator('#read-files-btn');
+    const status = page.locator('#status');
+
+    // Wait for Office.onReady to be called before clicking
+    await page.waitForFunction(() => document.getElementById('initials-display').textContent === 'JV');
+
+    await button.click();
+    await expect(status).toHaveText(/Reading active file\(s\)\.\.\./, { timeout: 10000 });
+    await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes\./, { timeout: 10000 });
+  });
+});


### PR DESCRIPTION
I have updated the "Read Active File" functionality to use pluralized terminology ("Read Active Files") to align with design consistency requirements, even though the technical implementation is currently limited to the single active presentation by the Office.js API. 

Key changes include:
- Renaming functions, event handlers, and UI labels in `index.js` and `index.html`.
- Improving the UI layout by wrapping the button in a `.button-container` and adjusting CSS margins.
- Standardizing status messages and console logs to use plural forms (e.g., "active file(s)").
- Implementing a robust E2E testing suite using Playwright, which mocks the Office environment to verify the UI and core logic.
- Updating the project's CI pipeline (`.github/workflows/ci.yml`) to support automated Playwright testing on Node.js 22.
- Adding `playwright.config.js` to handle the local development server lifecycle during tests.

I have verified all changes using the new test suite and manual frontend verification with screenshots. I also ensured that the repository remains clean by removing temporary logs and build artifacts.

---
*PR created automatically by Jules for task [13933330217940234952](https://jules.google.com/task/13933330217940234952) started by @JulienVink*