### PR TITLE
Pluralize 'Read Active Files' terminology and add UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         node-version: '20'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install chromium --with-deps
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log
+
+# Playwright
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,16 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: While the UI and terminology are pluralized for design consistency,
+ * the Office JS API currently limits retrieval to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
+
+  // Small delay to ensure the UI renders the initial status message
+  await new Promise(resolve => setTimeout(resolve, 10));
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -91,7 +96,7 @@ async function readActiveFile() {
     const sliceCount = file.sliceCount;
     const fileSize = file.size;
 
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slice(s)...`;
 
     // 2. Pre-allocate Uint8Array for the file content
     const fileData = new Uint8Array(fileSize);
@@ -109,11 +114,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading active file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  page.on('console', msg => console.log(`BROWSER [${msg.type()}]: ${msg.text()}`));
+
+  // Mock Office.js
+  await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async route => {
+    await route.fulfill({ body: '// Mock Office.js' });
+  });
+
+  await page.addInitScript(() => {
+    window.Office = {
+      onReady: (callback) => {
+        setTimeout(() => {
+          callback({ host: 'PowerPoint' });
+        }, 100);
+      },
+      HostType: { PowerPoint: 'PowerPoint' },
+      FileType: { Compressed: 'compressed' },
+      AsyncResultStatus: { Succeeded: 'succeeded', Failed: 'failed' },
+      context: {
+        document: {
+          getFileAsync: (fileType, options, callback) => {
+            setTimeout(() => {
+              callback({
+                status: 'succeeded',
+                value: {
+                  size: 100,
+                  sliceCount: 2,
+                  getSliceAsync: (index, sliceCallback) => {
+                    setTimeout(() => {
+                      sliceCallback({
+                        status: 'succeeded',
+                        value: { data: new Array(50).fill(0) }
+                      });
+                    }, 50);
+                  },
+                  closeAsync: (closeCallback) => {
+                    setTimeout(() => {
+                      closeCallback({ status: 'succeeded' });
+                    }, 10);
+                  }
+                }
+              });
+            }, 50);
+          }
+        }
+      }
+    };
+  });
+});
+
+test('UI elements are present and correctly labeled', async ({ page }) => {
+  await page.goto('/');
+
+  // Check title
+  await expect(page.locator('h1')).toHaveText('Eco-growth Discovery');
+
+  // Check button text
+  const readBtn = page.locator('#read-files-btn');
+  await expect(readBtn).toHaveText('Read Active Files');
+
+  // Check initials display
+  const initials = page.locator('#initials-display');
+  await expect(initials).toHaveText('JV');
+});
+
+test('Button container has correct styling', async ({ page }) => {
+  await page.goto('/');
+
+  const container = page.locator('.button-container');
+  await expect(container).toHaveCSS('margin-top', '30px');
+
+  const readBtn = page.locator('#read-files-btn');
+  const marginLeft = await readBtn.evaluate(el => window.getComputedStyle(el).marginLeft);
+  const marginRight = await readBtn.evaluate(el => window.getComputedStyle(el).marginRight);
+
+  // Verify it's centered (margin 0 auto results in equal left/right margins)
+  const ml = parseFloat(marginLeft);
+  const mr = parseFloat(marginRight);
+  expect(Math.abs(ml - mr)).toBeLessThan(1);
+  expect(ml).toBeGreaterThan(0);
+});
+
+test('Reading files updates status correctly', async ({ page }) => {
+  await page.goto('/');
+
+  // Wait for initials to ensure Office.onReady has completed and listeners are attached
+  const initials = page.locator('#initials-display');
+  await expect(initials).toHaveText('JV');
+
+  const readBtn = page.locator('#read-files-btn');
+  await readBtn.click();
+
+  const status = page.locator('#status');
+
+  // Wait for any of the expected status messages to appear
+  // This helps avoid flakiness if the first message is transient
+  await expect(status).not.toHaveText('', { timeout: 10000 });
+
+  const text = await status.textContent();
+  console.log('Final status text observed:', text);
+
+  // We check that the final state is reached and pluralization is correct
+  await expect(status).toHaveText('Successfully read active file(s): 100 bytes.');
+});


### PR DESCRIPTION
This PR updates the 'Eco-growth Discovery' add-in to use pluralized terminology for reading active presentation files, as requested. Although the underlying Office JS API is technically limited to the single active document, the UI now consistently uses 'Read Active Files' and 'file(s)' in status messages.

Key changes:
- Updated `index.html` button text and added a `.button-container` for styling.
- Renamed `readActiveFile` to `readActiveFiles` in `index.js` and standardized all user-facing status messages to be pluralized.
- Added a 10ms delay in the reading process to ensure initial status messages are rendered by the UI.
- Integrated `@playwright/test` for automated UI verification, including mocks for the Office.js environment.
- Configured `.gitignore` and `.github/workflows/ci.yml` to support the new testing infrastructure.

---
*PR created automatically by Jules for task [13976064155854168134](https://jules.google.com/task/13976064155854168134) started by @JulienVink*