### PR TITLE
Pluralize "Read Active Files" and add E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         node-version: '20'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log
+
+# Playwright
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency, though getFileAsync
+ * is limited to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -84,6 +86,9 @@ async function readActiveFile() {
     return;
   }
 
+  // Brief delay to ensure the UI renders the initial "Reading" message
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
   let file = null;
   try {
     // 1. Get the file handle
@@ -91,7 +96,7 @@ async function readActiveFile() {
     const sliceCount = file.sliceCount;
     const fileSize = file.size;
 
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slice(s)...`;
 
     // 2. Pre-allocate Uint8Array for the file content
     const fileData = new Uint8Array(fileSize);
@@ -109,9 +114,9 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.49.0",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.49.0",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,91 @@
+const { test, expect } = require('@playwright/test');
+
+test.beforeEach(async ({ page }) => {
+  // Mock Office.js
+  await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async (route) => {
+    await route.fulfill({ body: '// Mock Office.js' });
+  });
+
+  // Inject Office mock
+  await page.addInitScript(() => {
+    window.Office = {
+      onReady: (callback) => {
+        setTimeout(() => {
+          callback({ host: 'PowerPoint' });
+        }, 100);
+      },
+      HostType: { PowerPoint: 'PowerPoint' },
+      FileType: { Compressed: 'Compressed' },
+      AsyncResultStatus: { Succeeded: 'Succeeded', Failed: 'Failed' },
+      context: {
+        document: {
+          getFileAsync: (fileType, options, callback) => {
+            setTimeout(() => {
+              callback({
+                status: 'Succeeded',
+                value: {
+                  size: 100,
+                  sliceCount: 2,
+                  getSliceAsync: (index, sliceCallback) => {
+                    setTimeout(() => {
+                      sliceCallback({
+                        status: 'Succeeded',
+                        value: { data: new Uint8Array(50) }
+                      });
+                    }, 200); // 200ms delay to help capture intermediate states if needed
+                  },
+                  closeAsync: (closeCallback) => {
+                    setTimeout(() => {
+                      closeCallback();
+                    }, 100);
+                  }
+                }
+              });
+            }, 100);
+          }
+        }
+      }
+    };
+  });
+
+  await page.goto('/');
+});
+
+test('initialization updates initials', async ({ page }) => {
+  const initials = page.locator('#initials-display');
+  await expect(initials).toHaveText('JV');
+});
+
+test('read active files functionality', async ({ page }) => {
+  // Wait for initialization
+  await expect(page.locator('#initials-display')).toHaveText('JV');
+
+  const readBtn = page.locator('#read-files-btn');
+  const status = page.locator('#status');
+
+  await readBtn.click();
+
+  // Check initial reading message
+  await expect(status).toHaveText(/Reading active file\(s\)\.\.\./);
+
+  // Check file size/slices message
+  await expect(status).toHaveText(/File size: 100 bytes\. Reading 2 slice\(s\)\.\.\./);
+
+  // Check progress (assert on a reliable intermediate state)
+  await expect(status).toHaveText(/Reading progress: 50%/);
+
+  // Check success message (terminal state)
+  await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes\./);
+});
+
+test('ui layout: button is centered', async ({ page }) => {
+  const button = page.locator('#read-files-btn');
+  const box = await button.boundingBox();
+  const viewport = page.viewportSize();
+
+  // Check if button center is roughly at viewport center
+  const buttonCenter = box.x + box.width / 2;
+  const viewportCenter = viewport.width / 2;
+
+  expect(Math.abs(buttonCenter - viewportCenter)).toBeLessThan(5);
+});


### PR DESCRIPTION
This PR updates the "Read Active File" functionality to use pluralized terminology ("Read Active Files") throughout the UI and codebase for design consistency. It also refines the UI layout by centering the button within a dedicated container.

Key changes include:
- Renaming the core reading function to `readActiveFiles`.
- Updating all status messages and console logs to use plural phrasing.
- Adding a comprehensive automated test suite using Playwright, which mocks the Office.js environment to verify initialization, file reading progress, and UI layout.
- Updating project configuration (`package.json`, `.gitignore`, `playwright.config.js`) to support the new testing workflow.
- Ensuring a clean repository by excluding runtime logs and test artifacts.

---
*PR created automatically by Jules for task [972232484851514774](https://jules.google.com/task/972232484851514774) started by @JulienVink*