### PR TITLE
Pluralize "Read Active File" and add UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         node-version: '20'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+
+# Logs and test results
+server.log
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <button id="read-files-btn">Read Active Files</button>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ Office.onReady((info) => {
     // Attach event listener to the "Read Active File" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -72,10 +72,16 @@ function closeAsync(file) {
 
 /**
  * Reads the active PowerPoint file as a compressed byte stream.
+ * Note: While pluralized for design consistency, the Office JS API for PowerPoint
+ * is currently limited to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) {
+    status.textContent = "Reading active file(s)...";
+    // Brief delay to ensure UI renders the message before starting the process
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -91,7 +97,10 @@ async function readActiveFile() {
     const sliceCount = file.sliceCount;
     const fileSize = file.size;
 
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+    if (status) {
+      status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
 
     // 2. Pre-allocate Uint8Array for the file content
     const fileData = new Uint8Array(fileSize);
@@ -105,13 +114,15 @@ async function readActiveFile() {
 
       if (status) {
         status.textContent = `Reading progress: ${Math.round(((i + 1) / sliceCount) * 100)}%`;
+        // Yield to allow UI updates
+        await new Promise(resolve => setTimeout(resolve, 10));
       }
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.44.0",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,27 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -47,7 +47,7 @@ test.describe('Office Add-in UI Tests', () => {
       };
     });
 
-    await page.goto('http://localhost:3000/index.html');
+    await page.goto('/index.html');
   });
 
   test('should initialize with correct initials', async ({ page }) => {

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,72 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Office Add-in UI Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept Office.js request
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', route => {
+      route.fulfill({ body: '// Mock Office.js' });
+    });
+
+    // Mock Office environment
+    await page.addInitScript(() => {
+      window.Office = {
+        onReady: (callback) => {
+          setTimeout(() => {
+            callback({ host: 'PowerPoint' });
+          }, 100);
+        },
+        HostType: { PowerPoint: 'PowerPoint' },
+        FileType: { Compressed: 'Compressed' },
+        AsyncResultStatus: { Succeeded: 'Succeeded', Failed: 'Failed' },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              setTimeout(() => {
+                callback({
+                  status: 'Succeeded',
+                  value: {
+                    size: 200,
+                    sliceCount: 2,
+                    getSliceAsync: (index, sliceCallback) => {
+                      setTimeout(() => {
+                        sliceCallback({
+                          status: 'Succeeded',
+                          value: { data: new Uint8Array(100) }
+                        });
+                      }, 500); // Delay to capture progress updates
+                    },
+                    closeAsync: (closeCallback) => {
+                      setTimeout(() => closeCallback(), 100);
+                    }
+                  }
+                });
+              }, 500);
+            }
+          }
+        }
+      };
+    });
+
+    await page.goto('http://localhost:3000/index.html');
+  });
+
+  test('should initialize with correct initials', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    await expect(initials).toHaveText('JV');
+  });
+
+  test('should read active files and update status', async ({ page }) => {
+    const readBtn = page.locator('#read-files-btn');
+    const status = page.locator('#status');
+
+    await expect(page.locator('#initials-display')).toHaveText('JV');
+    await readBtn.click();
+
+    // Verify sequence of status messages
+    await expect(status).toHaveText('Reading active file(s)...');
+    await expect(status).toHaveText(/File size: 200 bytes. Reading 2 slices.../);
+    await expect(status).toHaveText('Reading progress: 50%');
+    // Note: '100%' might be skipped by Playwright's polling if the success message follows too quickly
+    await expect(status).toHaveText(/Successfully read active file\(s\): 200 bytes./);
+  });
+});


### PR DESCRIPTION
This PR updates the "Read Active File" functionality to "Read Active Files" to align with design requirements for pluralized terminology. While the Office JS API for PowerPoint is currently limited to a single active presentation, the UI and internal messaging now consistently use plural phrasing (e.g., "Reading active file(s)...").

Key changes:
1. **index.js**: Renamed the core function to `readActiveFiles`, updated status messages, and added intentional yields (`setTimeout`) to allow the UI to render progress updates during file processing. Added documentation regarding platform limitations.
2. **index.html**: Updated the button label to "Read Active Files".
3. **tests/ui.spec.js**: Introduced a comprehensive Playwright test suite that mocks the Office.js environment to verify initialization and the file-reading workflow.
4. **package.json**: Added Playwright as a development dependency and updated the test script.

Verification:
- Visual verification confirmed the new button text and status message sequence.
- All Playwright tests pass successfully.
- Cleaned up all temporary build and test artifacts.

---
*PR created automatically by Jules for task [12172558524293447232](https://jules.google.com/task/12172558524293447232) started by @JulienVink*