### PR TITLE
Implement 'Read Active Files' Pluralization and UI Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+server.log
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <button id="read-files-btn">Read Active Files</button>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,17 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency,
+ * though technically limited to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) {
+    status.textContent = "Reading active file(s)...";
+    // Brief delay to ensure UI renders the initial status
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -106,12 +112,14 @@ async function readActiveFile() {
       if (status) {
         status.textContent = `Reading progress: ${Math.round(((i + 1) / sliceCount) * 100)}%`;
       }
+      // Brief delay to allow for progress updates in the UI
+      await new Promise((resolve) => setTimeout(resolve, 10));
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
     const errorMsg = `Error reading file: ${error.message || error}`;
     console.error(errorMsg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,84 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Office Add-in UI Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock Office.js before the page loads
+    await page.addInitScript(() => {
+      window.Office = {
+        onReady: (callback) => {
+          // Simulate Office.js being ready with a slight delay
+          setTimeout(() => {
+            callback({ host: 'PowerPoint' });
+          }, 100);
+        },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              // Mock getFileAsync response
+              setTimeout(() => {
+                callback({
+                  status: 'succeeded',
+                  value: {
+                    size: 100,
+                    sliceCount: 2,
+                    getSliceAsync: (sliceIndex, sliceCallback) => {
+                      setTimeout(() => {
+                        sliceCallback({
+                          status: 'succeeded',
+                          value: {
+                            data: new Array(50).fill(0)
+                          }
+                        });
+                      }, 500); // 500ms delay to capture intermediate status
+                    },
+                    closeAsync: (closeCallback) => {
+                      setTimeout(closeCallback, 100);
+                    }
+                  }
+                });
+              }, 200);
+            }
+          }
+        },
+        FileType: { Compressed: 'compressed' },
+        AsyncResultStatus: { Succeeded: 'succeeded' },
+        HostType: { PowerPoint: 'PowerPoint' }
+      };
+    });
+
+    // Intercept the external Office.js script request and fulfill it with a mock
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: '// Mock Office.js'
+      });
+    });
+
+    await page.goto('http://localhost:3000/index.html');
+  });
+
+  test('should initialize and display initials "JV"', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    await expect(initials).toHaveText('JV');
+  });
+
+  test('should read active file and show progress', async ({ page }) => {
+    // Wait for initialization
+    await expect(page.locator('#initials-display')).toHaveText('JV');
+
+    const readBtn = page.locator('#read-files-btn');
+    const status = page.locator('#status');
+
+    await readBtn.click();
+
+    // Check for intermediate status
+    await expect(status).toHaveText(/Reading active file\(s\)\.\.\./);
+
+    // Check for progress update (due to 500ms delay in mock)
+    await expect(status).toHaveText(/Reading progress: 50%/);
+
+    // Check for success message
+    await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes\./);
+  });
+});


### PR DESCRIPTION
This PR updates the "Read Active File" feature to use pluralized terminology ("Read Active Files") throughout the UI and code, aligning with design consistency while acknowledging the technical limitation to the single active presentation via documentation.

Key changes:
- Renamed the core reading function and updated status messages.
- Improved UI responsiveness during file reading with strategic `setTimeout` delays.
- Added a robust end-to-end testing framework using Playwright, including mocks for the Office.js environment.
- Cleaned up the repository by ignoring build artifacts and logs.

---
*PR created automatically by Jules for task [5921759820509627795](https://jules.google.com/task/5921759820509627795) started by @JulienVink*