### PR TITLE
Pluralize Read Active Files functionality and add UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
     - run: npm test

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <button id="read-files-btn">Read Active Files</button>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,13 +21,79 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
+
+/**
+ * Reads the active PowerPoint presentation(s).
+ * Note: Pluralized terminology is used for design consistency,
+ * though the Office JS API for PowerPoint is limited to the single active document.
+ */
+async function readActiveFiles() {
+  const status = document.getElementById("status");
+  if (status) {
+    status.textContent = "Reading active file(s)...";
+    // Ensure UI renders the initial message
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+
+  if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
+    const errorMsg = "Office.js is not loaded or this is not an Office host.";
+    console.error(errorMsg);
+    if (status) status.textContent = errorMsg;
+    return;
+  }
+
+  let file = null;
+  try {
+    // 1. Get the file handle
+    file = await getFileAsync(Office.FileType.Compressed, { sliceSize: 65536 });
+    const sliceCount = file.sliceCount;
+    const fileSize = file.size;
+
+    if (status) {
+      status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+
+    // 2. Pre-allocate Uint8Array for the file content
+    const fileData = new Uint8Array(fileSize);
+    let offset = 0;
+
+    // 3. Read slices sequentially
+    for (let i = 0; i < sliceCount; i++) {
+      const slice = await getSliceAsync(file, i);
+      fileData.set(slice.data, offset);
+      offset += slice.data.length;
+
+      if (status) {
+        status.textContent = `Reading progress: ${Math.round(((i + 1) / sliceCount) * 100)}%`;
+        // Ensure UI has time to render progress updates
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+    }
+
+    if (status) {
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
+  } catch (error) {
+    const errorMsg = `Error reading file(s): ${error.message || error}`;
+    console.error(errorMsg);
+    if (status) status.textContent = errorMsg;
+  } finally {
+    // 4. Always close the file handle
+    if (file) {
+      await closeAsync(file);
+    }
+  }
+}
 
 /**
  * Promisified wrapper for Office.context.document.getFileAsync.
@@ -68,58 +134,4 @@ function closeAsync(file) {
       resolve();
     });
   });
-}
-
-/**
- * Reads the active PowerPoint file as a compressed byte stream.
- */
-async function readActiveFile() {
-  const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
-
-  if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
-    const errorMsg = "Office.js is not loaded or this is not an Office host.";
-    console.error(errorMsg);
-    if (status) status.textContent = errorMsg;
-    return;
-  }
-
-  let file = null;
-  try {
-    // 1. Get the file handle
-    file = await getFileAsync(Office.FileType.Compressed, { sliceSize: 65536 });
-    const sliceCount = file.sliceCount;
-    const fileSize = file.size;
-
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
-
-    // 2. Pre-allocate Uint8Array for the file content
-    const fileData = new Uint8Array(fileSize);
-    let offset = 0;
-
-    // 3. Read slices sequentially
-    for (let i = 0; i < sliceCount; i++) {
-      const slice = await getSliceAsync(file, i);
-      fileData.set(slice.data, offset);
-      offset += slice.data.length;
-
-      if (status) {
-        status.textContent = `Reading progress: ${Math.round(((i + 1) / sliceCount) * 100)}%`;
-      }
-    }
-
-    if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
-    }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
-  } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
-    console.error(errorMsg);
-    if (status) status.textContent = errorMsg;
-  } finally {
-    // 4. Always close the file handle
-    if (file) {
-      await closeAsync(file);
-    }
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.49.0",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.49.0",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,79 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Office Add-in UI', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock Office.js
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async (route) => {
+      await route.fulfill({ body: '// Mock Office.js' });
+    });
+
+    // Inject Office mock object before scripts load
+    await page.addInitScript(() => {
+      window.Office = {
+        onReady: (callback) => {
+          setTimeout(() => {
+            callback({ host: 'PowerPoint' });
+          }, 100);
+        },
+        HostType: { PowerPoint: 'PowerPoint' },
+        FileType: { Compressed: 'Compressed' },
+        AsyncResultStatus: { Succeeded: 'Succeeded', Failed: 'Failed' },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              setTimeout(() => {
+                callback({
+                  status: 'Succeeded',
+                  value: {
+                    size: 100,
+                    sliceCount: 2,
+                    getSliceAsync: (index, sliceCallback) => {
+                      setTimeout(() => {
+                        sliceCallback({
+                          status: 'Succeeded',
+                          value: { data: new Uint8Array(50) }
+                        });
+                      }, 500); // Delay to capture progress
+                    },
+                    closeAsync: (closeCallback) => {
+                      closeCallback();
+                    }
+                  }
+                });
+              }, 100);
+            }
+          }
+        }
+      };
+    });
+
+    await page.goto('/index.html');
+  });
+
+  test('should initialize and display initials', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    await expect(initials).toHaveText('JV');
+  });
+
+  test('should read active files and show progress', async ({ page }) => {
+    // Wait for initialization
+    await expect(page.locator('#initials-display')).toHaveText('JV');
+
+    const readBtn = page.locator('#read-files-btn');
+    await readBtn.click();
+
+    const status = page.locator('#status');
+
+    // Check initial reading message
+    await expect(status).toHaveText(/Reading active file\(s\)\.\.\./);
+
+    // Check file size message
+    await expect(status).toHaveText(/File size: 100 bytes/);
+
+    // Check progress - because of the delay in getSliceAsync, we should be able to catch 50%
+    await expect(status).toHaveText(/Reading progress: 50%/);
+
+    // Check final success message
+    await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes/);
+  });
+});


### PR DESCRIPTION
This change updates the Office Add-in to use pluralized terminology ("Read Active Files") for design consistency across the UI and implementation. It also introduces progress reporting with UI rendering delays and establishes a Playwright-based testing infrastructure to ensure the add-in initializes and reads files correctly in simulated Office environments.

---
*PR created automatically by Jules for task [15487274494353928957](https://jules.google.com/task/15487274494353928957) started by @JulienVink*