### PR TITLE
Pluralize Read Active File(s) and add UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+
+# Playwright
+playwright-report/
+test-results/
+blob-report/
+playwright/.cache/
+
+# Development
+server.log

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <button id="read-files-btn">Read Active File(s)</button>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active File(s)" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: While the UI and terminology are pluralized for design consistency,
+ * the current Office JS API is limited to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,11 +111,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "npx playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,87 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Eco-growth Discovery Add-in UI', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock Office.js before the page loads
+    await page.addInitScript(() => {
+      window.Office = {
+        onReady: (callback) => {
+          // Simulate Office.js being ready with PowerPoint host
+          setTimeout(() => {
+            callback({ host: 'PowerPoint' });
+          }, 100);
+        },
+        HostType: { PowerPoint: 'PowerPoint' },
+        FileType: { Compressed: 'Compressed' },
+        AsyncResultStatus: { Succeeded: 'Succeeded', Failed: 'Failed' },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              // Simulate successful file retrieval
+              setTimeout(() => {
+                callback({
+                  status: 'Succeeded',
+                  value: {
+                    size: 100,
+                    sliceCount: 2,
+                    getSliceAsync: (index, sliceCallback) => {
+                      setTimeout(() => {
+                        sliceCallback({
+                          status: 'Succeeded',
+                          value: { data: new Uint8Array(50) }
+                        });
+                      }, 100);
+                    },
+                    closeAsync: (closeCallback) => {
+                      setTimeout(() => {
+                        closeCallback();
+                      }, 50);
+                    }
+                  }
+                });
+              }, 100);
+            }
+          }
+        }
+      };
+    });
+
+    // Intercept the external Office.js script to prevent network requests and errors
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: '// Mock Office.js'
+      });
+    });
+
+    await page.goto('/index.html');
+  });
+
+  test('should initialize and display initials', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    await expect(initials).toHaveText('JV');
+  });
+
+  test('should read active file(s) and update status', async ({ page }) => {
+    // Wait for initialization
+    await expect(page.locator('#initials-display')).toHaveText('JV');
+
+    const readBtn = page.locator('#read-files-btn');
+    await expect(readBtn).toHaveText('Read Active File(s)');
+
+    await readBtn.click();
+
+    const status = page.locator('#status');
+
+    // Check for intermediate status messages
+    await expect(status).toHaveText(/Reading active file\(s\)\.\.\./);
+    await expect(status).toHaveText(/File size: 100 bytes\. Reading 2 slices\.\.\./);
+
+    // Check for progress updates
+    await expect(status).toHaveText(/Reading progress: 50%/);
+
+    // Check for final success message
+    await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes\./);
+  });
+});


### PR DESCRIPTION
This change updates the 'Eco-growth Discovery' add-in to use pluralized terminology ('active file(s)') for its primary functionality, aligning with design consistency goals. Although the underlying Office JS API for PowerPoint currently supports only the single active presentation, the UI and documentation now reflect this broader terminology. Additionally, the change introduces a robust UI testing suite using Playwright with a mocked Office environment and updates the GitHub Actions CI workflow to ensure ongoing quality.

---
*PR created automatically by Jules for task [14490721402669775246](https://jules.google.com/task/14490721402669775246) started by @JulienVink*