### PR TITLE
feat: update taskpane to use pluralized terminology for reading active files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers and Dependencies
+      run: npx playwright install chromium --with-deps
     - run: npm test

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <button id="read-files-btn">Read Active File(s)</button>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active File(s)" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active presentation(s) / active file(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency, although the Office JS API (getFileAsync)
+ * is technically limited to the single active document hosting the add-in.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,11 +111,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading active file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "npx playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,102 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Eco-growth Discovery Add-in UI Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept office.js script loading and fulfill with empty mock script
+    // to allow our custom window.Office mock injected via addInitScript to be used.
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: '// Mock Office.js',
+      });
+    });
+
+    // Mock the Office namespace before the page loads
+    await page.addInitScript(() => {
+      window.Office = {
+        HostType: {
+          PowerPoint: 'PowerPoint',
+        },
+        FileType: {
+          Compressed: 'Compressed',
+        },
+        AsyncResultStatus: {
+          Succeeded: 'Succeeded',
+          Failed: 'Failed',
+        },
+        onReady: (callback) => {
+          // Initialize with a slight delay to allow scripts to load and attach event listeners
+          setTimeout(() => {
+            callback({ host: 'PowerPoint' });
+          }, 100);
+        },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              // Simulate async file retrieval with a mock file object
+              setTimeout(() => {
+                const mockFile = {
+                  size: 150000, // 150 KB
+                  sliceCount: 3,
+                  getSliceAsync: (sliceIndex, sliceCallback) => {
+                    setTimeout(() => {
+                      // Generate a block of data for each slice
+                      const sliceSize = 65536;
+                      const dataSize = (sliceIndex === 2) ? (150000 - 2 * sliceSize) : sliceSize;
+                      const sliceData = new Uint8Array(dataSize);
+                      sliceCallback({
+                        status: 'Succeeded',
+                        value: {
+                          data: Array.from(sliceData),
+                          index: sliceIndex,
+                        },
+                      });
+                    }, 500); // 500ms delay to capture intermediate progress states
+                  },
+                  closeAsync: (closeCallback) => {
+                    setTimeout(() => {
+                      closeCallback({ status: 'Succeeded' });
+                    }, 50);
+                  },
+                };
+                callback({
+                  status: 'Succeeded',
+                  value: mockFile,
+                });
+              }, 100);
+            },
+          },
+        },
+      };
+    });
+
+    await page.goto('/');
+  });
+
+  test('should display initials "JV" after initialization', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    // Verify initials transition to 'JV' after Office.onReady callback fires
+    await expect(initials).toHaveText('JV');
+  });
+
+  test('should read file slices and update progress and success message', async ({ page }) => {
+    // Wait for add-in to initialize
+    await expect(page.locator('#initials-display')).toHaveText('JV');
+
+    const status = page.locator('#status');
+    const readBtn = page.locator('#read-files-btn');
+
+    // Click the Read button
+    await readBtn.click();
+
+    // Verify progress text and final success message using regex
+    await expect(status).toHaveText(/Reading active file\(s\)\.\.\./);
+
+    // Verify intermediate progress states and success message
+    await expect(status).toHaveText(/(Reading progress: (33|67|100)%|Successfully read active file\(s\): 150000 bytes\.)/);
+
+    // Verify final success message
+    await expect(status).toHaveText('Successfully read active file(s): 150000 bytes.', { timeout: 5000 });
+  });
+});


### PR DESCRIPTION
Updated the Eco-growth Discovery taskpane UI and backing Javascript to read 'active file(s)' in standard pluralized terminology for design consistency. Configured Playwright end-to-end UI tests to fully verify initialization and file slice loading, and updated GitHub Actions CI configuration to run tests on Node 22.

---
*PR created automatically by Jules for task [14755776186384561136](https://jules.google.com/task/14755776186384561136) started by @JulienVink*