### PR TITLE
Support reading active file(s) with pluralized terminology and add automated Playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         node-version: '20'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers and Dependencies
+      run: npx playwright install chromium --with-deps
     - run: npm test

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <button id="read-files-btn">Read Active File(s)</button>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ Office.onReady((info) => {
     // Attach event listener to the "Read Active File" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,14 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active file(s)/presentation(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency, although the
+ * Office JS API (getFileAsync) is technically limited to the single active document
+ * hosting the add-in.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -91,7 +94,7 @@ async function readActiveFile() {
     const sliceCount = file.sliceCount;
     const fileSize = file.size;
 
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+    if (status) status.textContent = `Active file(s) size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
 
     // 2. Pre-allocate Uint8Array for the file content
     const fileData = new Uint8Array(fileSize);
@@ -109,11 +112,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading active file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,27 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,96 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Eco-growth Discovery Taskpane UI Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept external Office.js script to prevent network calls and let our mock take effect.
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: '// Mocked Office.js loaded',
+      });
+    });
+
+    // Add init script to mock the Office namespace and its API before index.js runs.
+    await page.addInitScript(() => {
+      window.Office = {
+        HostType: { PowerPoint: 'PowerPoint' },
+        FileType: { Compressed: 'Compressed' },
+        AsyncResultStatus: {
+          Succeeded: 'Succeeded',
+          Failed: 'Failed',
+        },
+        context: {
+          document: {
+            getFileAsync(fileType, options, callback) {
+              // Simulate async nature of PowerPoint Office.js
+              setTimeout(() => {
+                callback({
+                  status: window.Office.AsyncResultStatus.Succeeded,
+                  value: {
+                    sliceCount: 2,
+                    size: 100,
+                    getSliceAsync(sliceIndex, sliceCallback) {
+                      setTimeout(() => {
+                        sliceCallback({
+                          status: window.Office.AsyncResultStatus.Succeeded,
+                          value: {
+                            // Slice size/data mock
+                            data: new Uint8Array(50),
+                          },
+                        });
+                      }, 500); // Wait 500ms to allow UI progress assertions to catch the transition states
+                    },
+                    closeAsync(closeCallback) {
+                      setTimeout(() => {
+                        closeCallback();
+                      }, 10);
+                    },
+                  },
+                });
+              }, 100);
+            },
+          },
+        },
+        onReady(callback) {
+          // Trigger callbacks after DOM scripts execute, simulating native behavior
+          setTimeout(() => {
+            callback({ host: 'PowerPoint' });
+          }, 100);
+        },
+      };
+    });
+
+    await page.goto('/');
+  });
+
+  test('should display co-op initials as "JV" upon Office onReady', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    await expect(initials).toHaveText('JV');
+  });
+
+  test('should read presentation files and display reading progress and success messages', async ({ page }) => {
+    // Wait for initials-display to update to "JV" (signals Office is ready and handlers attached)
+    await expect(page.locator('#initials-display')).toHaveText('JV');
+
+    const readBtn = page.locator('#read-files-btn');
+    const status = page.locator('#status');
+
+    await expect(status).toBeEmpty();
+
+    // Trigger read action
+    await readBtn.click();
+
+    // Check intermediate reading states (due to the 500ms delay per slice, we can catch progress)
+    await expect(status).toHaveText(/Reading active file\(s\)\.\.\./);
+
+    // Check intermediate size message
+    await expect(status).toHaveText(/Active file\(s\) size: 100 bytes\. Reading 2 slices\.\.\./);
+
+    // Wait and verify first slice progress (50%)
+    await expect(status).toHaveText(/Reading progress: 50%/);
+
+    // Wait and verify complete progress / success message
+    await expect(status).toHaveText(/Successfully read active file\(s\): 100 bytes\./);
+  });
+});


### PR DESCRIPTION
Support reading active file(s) with pluralized terminology in the taskpane and status messages. We renamed the core reading function to readActiveFiles, updated the button label to 'Read Active File(s)', standardized all related documentation/logs/status messages, and introduced full E2E/UI tests using Playwright.

---
*PR created automatically by Jules for task [14882921820344479462](https://jules.google.com/task/14882921820344479462) started by @JulienVink*