### PR TITLE
Implement pluralized terminology for Read Active File(s) and configure automated Playwright testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         node-version: '20'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers
+      run: npx playwright install chromium --with-deps
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+
+# Playwright
+playwright-report/
+test-results/
+blob-report/
+playwright/.cache/

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <button id="read-files-btn">Read Active File(s)</button>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ Office.onReady((info) => {
     // Attach event listener to the "Read Active File" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,15 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint presentation(s) as a compressed byte stream.
+ *
+ * NOTE: Pluralized terminology (e.g., "active file(s)", "presentation(s)") is used
+ * for design and UI consistency, although the Office JS API (getFileAsync) is
+ * technically limited to reading the single active document/presentation hosting the add-in.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -91,9 +95,9 @@ async function readActiveFile() {
     const sliceCount = file.sliceCount;
     const fileSize = file.size;
 
-    if (status) status.textContent = `File size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
+    if (status) status.textContent = `Active file(s) size: ${fileSize} bytes. Reading ${sliceCount} slices...`;
 
-    // 2. Pre-allocate Uint8Array for the file content
+    // 2. Pre-allocate Uint8Array for the presentation(s) content
     const fileData = new Uint8Array(fileSize);
     let offset = 0;
 
@@ -109,11 +113,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading active file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,26 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 10000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,103 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Eco-growth Discovery Taskpane UI Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept external Office.js load to prevent fetching external scripts
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: '// Mock Office.js library loader',
+      });
+    });
+
+    // Inject mock Office object BEFORE document starts loading/parsing scripts
+    await page.addInitScript(() => {
+      window.Office = {
+        HostType: {
+          PowerPoint: 'PowerPoint'
+        },
+        FileType: {
+          Compressed: 'Compressed'
+        },
+        AsyncResultStatus: {
+          Succeeded: 'Succeeded',
+          Failed: 'Failed'
+        },
+        onReady: (callback) => {
+          // Trigger the callback asynchronously to simulate Office initialization flow
+          setTimeout(() => {
+            callback({ host: 'PowerPoint' });
+          }, 100);
+        },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              // Simulate small delay for reading active file(s)
+              setTimeout(() => {
+                callback({
+                  status: 'Succeeded',
+                  value: {
+                    size: 131072, // 128 KB
+                    sliceCount: 2,
+                    getSliceAsync: (sliceIndex, sliceCallback) => {
+                      setTimeout(() => {
+                        sliceCallback({
+                          status: 'Succeeded',
+                          value: {
+                            data: new Uint8Array(65536) // 64 KB slice data
+                          }
+                        });
+                      }, 500); // 500ms delay to guarantee intermediate updates are captured
+                    },
+                    closeAsync: (closeCallback) => {
+                      setTimeout(() => {
+                        closeCallback({ status: 'Succeeded' });
+                      }, 50);
+                    }
+                  }
+                });
+              }, 100);
+            }
+          }
+        }
+      };
+    });
+
+    await page.goto('/');
+  });
+
+  test('should display initials "JV" after Office initialization', async ({ page }) => {
+    // Wait for the initials to transition from '--' to 'JV'
+    const initialsDisplay = page.locator('#initials-display');
+    await expect(initialsDisplay).toHaveText('JV');
+  });
+
+  test('should perform full file reading flow and show progress updates', async ({ page }) => {
+    // Wait for Office to be ready
+    const initialsDisplay = page.locator('#initials-display');
+    await expect(initialsDisplay).toHaveText('JV');
+
+    const status = page.locator('#status');
+    const readBtn = page.locator('#read-files-btn');
+
+    // Initially status should be empty
+    await expect(status).toBeEmpty();
+
+    // Click on Read Active File(s)
+    await readBtn.click();
+
+    // Verify transition of states using regex matchers or sequential asserts
+    // Stage 1: Initiating file reading
+    await expect(status).toHaveText('Reading active file(s)...');
+
+    // Stage 2: Retrieved file size info
+    await expect(status).toHaveText(/Active file\(s\) size: 131072 bytes\. Reading 2 slices\.\.\./);
+
+    // Stage 3 & 4: Progress stages (e.g. 50% -> 100%) and then success message
+    await expect(status).toHaveText(/(Reading progress: (50|100)%|Successfully read active file\(s\): 131072 bytes\.)/);
+
+    // Ensure final state is reached
+    await expect(status).toHaveText('Successfully read active file(s): 131072 bytes.');
+  });
+});


### PR DESCRIPTION
This pull request updates the taskpane UI and the code in index.js to use pluralized "Read Active File(s)" terminology for design/UI consistency. It also integrates Playwright for automated E2E UI testing, mocks the Office.js environment, and updates the GitHub CI workflow to run tests.

---
*PR created automatically by Jules for task [10127099707413859346](https://jules.google.com/task/10127099707413859346) started by @JulienVink*