### PR TITLE
Implement Read Active Files with Pluralized Terminology and Playwright UI Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
         node-version: '20'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright browsers and dependencies
+      run: npx playwright install chromium --with-deps
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+
+# Playwright
+playwright-report/
+test-results/
+blob-report/
+playwright/.cache/

--- a/index.html
+++ b/index.html
@@ -28,9 +28,12 @@
             color: #666;
             margin-top: 10px;
         }
+        .button-container {
+            margin-top: 30px;
+        }
         #read-files-btn {
             display: block;
-            margin: 30px auto 0;
+            margin: 0 auto;
             padding: 10px 20px;
             background-color: #217346;
             color: white;
@@ -65,7 +68,9 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <div class="button-container">
+        <button id="read-files-btn">Read Active Files</button>
+    </div>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active Files" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active PowerPoint file(s) as a compressed byte stream.
+ * Note: While pluralized terminology is used for design consistency, the
+ * current implementation is limited to the single active presentation.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,11 +111,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "npx playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,78 @@
+const { test, expect } = require('@playwright/test');
+
+test.beforeEach(async ({ page }) => {
+  // Mock Office.js
+  await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', async (route) => {
+    await route.fulfill({ body: '// Mock Office.js' });
+  });
+
+  await page.addInitScript(() => {
+    window.Office = {
+      onReady: (callback) => {
+        setTimeout(() => {
+          callback({ host: 'PowerPoint' });
+        }, 100);
+      },
+      HostType: { PowerPoint: 'PowerPoint' },
+      FileType: { Compressed: 'Compressed' },
+      AsyncResultStatus: { Succeeded: 'Succeeded', Failed: 'Failed' },
+      context: {
+        document: {
+          getFileAsync: (fileType, options, callback) => {
+            setTimeout(() => {
+              callback({
+                status: 'Succeeded',
+                value: {
+                  size: 100,
+                  sliceCount: 2,
+                  getSliceAsync: (index, sliceCallback) => {
+                    setTimeout(() => {
+                      sliceCallback({
+                        status: 'Succeeded',
+                        value: { data: new Uint8Array(50) }
+                      });
+                    }, 500); // 500ms delay to capture intermediate status
+                  },
+                  closeAsync: (closeCallback) => {
+                    setTimeout(() => {
+                      closeCallback();
+                    }, 100);
+                  }
+                }
+              });
+            }, 100);
+          }
+        }
+      }
+    };
+  });
+
+  await page.goto('/index.html');
+});
+
+test('should initialize with JV initials', async ({ page }) => {
+  const initials = page.locator('#initials-display');
+  await expect(initials).toHaveText('JV');
+});
+
+test('should read active files successfully', async ({ page }) => {
+  // Wait for initialization
+  await expect(page.locator('#initials-display')).toHaveText('JV');
+
+  const readBtn = page.locator('#read-files-btn');
+  const status = page.locator('#status');
+
+  await readBtn.click();
+
+  // Check initial status
+  await expect(status).toHaveText('Reading active file(s)...');
+
+  // Check file size info
+  await expect(status).toHaveText(/File size: 100 bytes\. Reading 2 slices\.\.\./);
+
+  // Check progress - use regex assertion to handle skipped states safely
+  await expect(status).toHaveText(/(Reading progress: (50|100)%|Successfully read active file\(s\): 100 bytes\.)/);
+
+  // Check success message
+  await expect(status).toHaveText('Successfully read active file(s): 100 bytes.');
+});


### PR DESCRIPTION
This change updates the PowerPoint add-in to use pluralized 'Read Active Files' and 'presentation(s)' terminology for consistency across the codebase, HTML interface, and user status messages. It also sets up Playwright E2E UI testing in `tests/ui.spec.js` and customizes `.gitignore` to prevent committing report or log artifacts.

---
*PR created automatically by Jules for task [1925536046024135998](https://jules.google.com/task/1925536046024135998) started by @JulienVink*