### PR TITLE
Read Active File(s) Pluralization and Playwright E2E UI Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm install
+    - name: Install Playwright Browsers and Deps
+      run: npx playwright install chromium --with-deps
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ appengine-generated/
 # Node.js
 node_modules/
 npm-debug.log
+
+# Playwright & test artifacts
+playwright-report/
+test-results/
+blob-report/
+playwright/.cache/
+server.log

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="label">Co Op Initials</div>
     <div id="initials-display">--</div>
 
-    <button id="read-files-btn">Read Active File</button>
+    <button id="read-files-btn">Read Active File(s)</button>
     <div id="status"></div>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ Office.onReady((info) => {
       initialsDisplay.textContent = initials;
     }
 
-    // Attach event listener to the "Read Active File" button
+    // Attach event listener to the "Read Active File(s)" button
     const readBtn = document.getElementById("read-files-btn");
     if (readBtn) {
-      readBtn.onclick = readActiveFile;
+      readBtn.onclick = readActiveFiles;
     }
   }
 });
@@ -71,11 +71,13 @@ function closeAsync(file) {
 }
 
 /**
- * Reads the active PowerPoint file as a compressed byte stream.
+ * Reads the active presentation(s) / active file(s) as a compressed byte stream.
+ * Note: Pluralized terminology is used for design consistency, although the Office JS API (getFileAsync)
+ * is technically limited to the single active document hosting the add-in.
  */
-async function readActiveFile() {
+async function readActiveFiles() {
   const status = document.getElementById("status");
-  if (status) status.textContent = "Reading file...";
+  if (status) status.textContent = "Reading active file(s)...";
 
   if (typeof Office === "undefined" || !Office.context || !Office.context.document) {
     const errorMsg = "Office.js is not loaded or this is not an Office host.";
@@ -109,11 +111,11 @@ async function readActiveFile() {
     }
 
     if (status) {
-      status.textContent = `Successfully read active file: ${fileSize} bytes.`;
+      status.textContent = `Successfully read active file(s): ${fileSize} bytes.`;
     }
-    console.log(`Read ${fileSize} bytes from the active presentation.`);
+    console.log(`Read ${fileSize} bytes from the active presentation(s).`);
   } catch (error) {
-    const errorMsg = `Error reading file: ${error.message || error}`;
+    const errorMsg = `Error reading active file(s): ${error.message || error}`;
     console.error(errorMsg);
     if (status) status.textContent = errorMsg;
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,24 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "http-server": "^14.1.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ansi-styles": {
@@ -218,6 +235,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -458,6 +490,38 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "http-server -p 3000",
-    "test": "echo \"No tests implemented yet\" && exit 0"
+    "test": "npx playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/JulienVink/eco-growth-discovery#readme",
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "http-server": "^14.1.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,27 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,95 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Eco-growth Discovery Taskpane UI Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept external Office.js script and return mock body to avoid external network dependencies
+    await page.route('https://appsforoffice.microsoft.com/lib/1/hosted/office.js', (route) => {
+      route.fulfill({
+        contentType: 'application/javascript',
+        body: '// Mock Office.js'
+      });
+    });
+
+    // Inject the mocked Office namespace before any script runs
+    await page.addInitScript(() => {
+      window.Office = {
+        onReady: (callback) => {
+          setTimeout(() => {
+            callback({ host: 'PowerPoint' });
+          }, 100);
+        },
+        HostType: {
+          PowerPoint: 'PowerPoint'
+        },
+        FileType: {
+          Compressed: 'Compressed'
+        },
+        AsyncResultStatus: {
+          Succeeded: 'Succeeded',
+          Failed: 'Failed'
+        },
+        context: {
+          document: {
+            getFileAsync: (fileType, options, callback) => {
+              const mockFile = {
+                size: 100,
+                sliceCount: 2,
+                getSliceAsync: (sliceIndex, sliceCallback) => {
+                  setTimeout(() => {
+                    sliceCallback({
+                      status: 'Succeeded',
+                      value: {
+                        data: new Uint8Array(50) // 2 slices of 50 bytes
+                      }
+                    });
+                  }, 500); // 500ms delay to ensure intermediate states are captured
+                },
+                closeAsync: (closeCallback) => {
+                  setTimeout(() => {
+                    closeCallback();
+                  }, 50);
+                }
+              };
+              setTimeout(() => {
+                callback({
+                  status: 'Succeeded',
+                  value: mockFile
+                });
+              }, 100);
+            }
+          }
+        }
+      };
+    });
+
+    await page.goto('/');
+  });
+
+  test('should display initials after Office initialization', async ({ page }) => {
+    const initials = page.locator('#initials-display');
+    await expect(initials).toHaveText('JV');
+  });
+
+  test('should read file and display status progression', async ({ page }) => {
+    // Ensure Office initialized first
+    await expect(page.locator('#initials-display')).toHaveText('JV');
+
+    const readBtn = page.locator('#read-files-btn');
+    const status = page.locator('#status');
+
+    await readBtn.click();
+
+    // Check initial reading state
+    await expect(status).toHaveText('Reading active file(s)...');
+
+    // Wait for the file size text
+    await expect(status).toHaveText(/File size: 100 bytes\. Reading 2 slices\.\.\./);
+
+    // Wait for progress (Reading progress: 50%, then 100%) or final success message
+    // A regex that matches the sequence or final success
+    await expect(status).toHaveText(/(Reading progress: (50|100)%|Successfully read active file\(s\): 100 bytes\.)/);
+
+    // Wait until the final success status is reached
+    await expect(status).toHaveText('Successfully read active file(s): 100 bytes.');
+  });
+});


### PR DESCRIPTION
Renamed readActiveFile to readActiveFiles, updated index.html button to show 'Read Active File(s)', added Playwright configuration and end-to-end UI tests to tests/ui.spec.js, configured CI workflow to run with Node.js 22 and execute the tests, and updated .gitignore to exclude test artifacts.

---
*PR created automatically by Jules for task [17395403026472231529](https://jules.google.com/task/17395403026472231529) started by @JulienVink*