### PR TITLE
Fix Read Active File(s) button text assertion in tests

### DIFF
--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -84,7 +84,7 @@ test.describe('Eco-growth Discovery Taskpane UI Tests', () => {
     await expect(initialsDisplay).toHaveText('JV');
 
     const readBtn = page.locator('#read-files-btn');
-    await expect(readBtn).toHaveText('Read Active File');
+    await expect(readBtn).toHaveText('Read Active File(s)');
 
     const status = page.locator('#status');
     await expect(status).toBeEmpty();


### PR DESCRIPTION
This PR corrects a mismatched text assertion in the Playwright test suite `tests/ui.spec.js`. Specifically, the test was asserting that the read active files button text was 'Read Active File' when the taskpane UI actually displays 'Read Active File(s)' in order to remain consistent with pluralized terminology. Updating this assertion makes the entire test suite pass successfully.

---
*PR created automatically by Jules for task [1378867344033010902](https://jules.google.com/task/1378867344033010902) started by @JulienVink*