### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ZinoFlo/Fantasyspot/security/code-scanning/1](https://github.com/ZinoFlo/Fantasyspot/security/code-scanning/1)

To fix this, add an explicit `permissions` block in `.github/workflows/ci.yml`.  
Best approach here: define permissions at the workflow root so all jobs in this workflow inherit least privilege unless overridden later.

For this CI workflow (checkout + install + test), the minimal needed permission is:

- `contents: read`

Edit region: immediately after the `on:` trigger block and before `jobs:`.  
No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
